### PR TITLE
2358 Add option to add custom positioner and reset callback methods for guide rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,13 +2,7 @@ import './style.css';
 import Snapster from './src/snapster';
 
 const container = document.querySelector('.page');
-
-const snapster = new Snapster({
-  document,
-  container,
-  threshold: 8,
-  scale: 1
-});
+const snapster = new Snapster({ document, container });
 
 let drag = null;
 let shiftX;

--- a/main.js
+++ b/main.js
@@ -7,9 +7,7 @@ const snapster = new Snapster({
   document,
   container,
   threshold: 8,
-  setup: (element, edge) => {
-    element.className = `guide guide--${edge.type} guide--${edge.direction}`;
-  }
+  scale: 1
 });
 
 let drag = null;

--- a/src/box.ts
+++ b/src/box.ts
@@ -7,13 +7,13 @@ export default class Box {
   height: number;
   type?: string;
 
-  constructor( options: {
-      x: number,
-      y: number,
-      width: number,
-      height: number,
-      type?: string
-    }) {
+  constructor(options: {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    type?: string
+  }) {
     this.x = options.x;
     this.y = options.y;
     this.width = options.width;

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -1,15 +1,9 @@
 export default class Edge {
-  direction: string;
+  direction: 'horizontal' | 'vertical';
   position: number;
   type?: string
 
-  constructor(
-    options: {
-      direction: string,
-      position: number,
-      type?: string
-    }
-  ) {
+  constructor(options: { direction: 'horizontal' | 'vertical', position: number, type?: string }) {
     this.direction = options.direction;
     this.position = options.position;
     this.type = options.type;

--- a/src/edge.ts
+++ b/src/edge.ts
@@ -1,9 +1,11 @@
+type DirectionType = 'horizontal' | 'vertical';
+
 export default class Edge {
-  direction: 'horizontal' | 'vertical';
+  direction: DirectionType;
   position: number;
   type?: string
 
-  constructor(options: { direction: 'horizontal' | 'vertical', position: number, type?: string }) {
+  constructor(options: { direction: DirectionType, position: number, type?: string }) {
     this.direction = options.direction;
     this.position = options.position;
     this.type = options.type;

--- a/src/interfaces/element-interface.ts
+++ b/src/interfaces/element-interface.ts
@@ -2,9 +2,9 @@ export default interface ElementInterface {
   tagName: string;
   className: string;
   style: {
-    top?: string,
-    right?: string,
-    bottom?: string,
-    left?: string,
+    top?: string | null,
+    right?: string | null,
+    bottom?: string | null,
+    left?: string | null,
   };
 }

--- a/src/snap.ts
+++ b/src/snap.ts
@@ -14,9 +14,12 @@ export default class Snap {
   }
 
   to(box: Box): PointInterface {
+    const grid = this.grid;
+    const { left, center, right, width, x, top, middle, bottom, height, y } = box;
+
     return {
-      x: this.snapAxis(this.grid.verticals, box.left, box.center, box.right, box.width, box.x),
-      y: this.snapAxis(this.grid.horizontals, box.top, box.middle, box.bottom, box.height, box.y)
+      x: this.snapAxis(grid.verticals, left, center, right, width, x),
+      y: this.snapAxis(grid.horizontals, top, middle, bottom, height, y)
     };
   }
 
@@ -29,20 +32,23 @@ export default class Snap {
     fallback: number
   ): number {
     for (let edge of edges) {
-      const startMatch = this.snapped(edge, start, 0, fallback);
-      if (startMatch !== fallback) return startMatch;
-
-      const middleMatch = this.snapped(edge, middle, extent / 2, fallback);
-      if (middleMatch !== fallback) return middleMatch;
-
-      const endMatch = this.snapped(edge, end, extent, fallback);
-      if (endMatch !== fallback) return endMatch;
+      for (const [position, offset] of [
+        [start, 0], [middle, extent / 2], [end, extent]
+      ]) {
+        const snapped = this.snapped(edge, position, offset, fallback);
+        if (snapped !== fallback) return snapped;
+      }
     }
 
     return fallback;
   }
 
-  private snapped(edge: Edge, position: number, offset: number, fallback: number): number {
+  private snapped(
+    edge: Edge,
+    position: number,
+    offset: number,
+    fallback: number
+  ): number {
     return this.snappable(edge.position, position) ? edge.position - offset : fallback;
   }
 

--- a/src/snapster.ts
+++ b/src/snapster.ts
@@ -21,18 +21,21 @@ export default class Snapster {
       document: DocumentInterface,
       container: ContainerInterface,
       threshold?: number,
-      setup?: (element: ElementInterface, edge: Edge) => void
+      setup?: (options: { element: ElementInterface, edge: Edge }) => void
+      positioner?: (options: { element: ElementInterface, edge: Edge }) => void
+      reset?: (options: { element: ElementInterface }) => void
     }
   ) {
     this.grid = new Grid();
     this.snapping = new Snap({ grid: this.grid, threshold: options.threshold || 8 });
+
     this.renderer = new Renderer(
       {
         document: options.document,
         container: options.container,
-        setup: options.setup || ((element, edge) => {
-          element.className = `guide guide--${edge.direction}`;
-        })
+        setup: options.setup,
+        positioner: options.positioner,
+        reset: options.reset
       }
     );
   }

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -22,13 +22,12 @@ test('can draw guides', () => {
     }
   };
 
-  const guides = new Renderer({
+  const renderer = new Renderer({
     document,
-    container: body,
-    setup: (element, edge) => element.className = `guide guide--${edge.direction}`
+    container: body
   });
 
-  guides.draw([
+  renderer.draw([
     new Edge({ direction: 'horizontal', position: 100 }),
     new Edge({ direction: 'horizontal', position: 200 }),
     new Edge({ direction: 'vertical', position: 300 }),
@@ -71,6 +70,157 @@ test('can draw guides', () => {
   ]);
 });
 
+test('can have custom positioning guides', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+    removeChild(child: ElementInterface) {
+      this.children.filter(existing => existing === child );
+    }
+  };
+
+  const renderer = new Renderer({
+    document,
+    container: body,
+    positioner: options => {
+      const { element, edge } = options;
+      const position = edge.position * 0.3;
+
+      element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${position}px`;
+    }
+  });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100 }),
+    new Edge({ direction: 'horizontal', position: 200 }),
+    new Edge({ direction: 'vertical', position: 300 }),
+    new Edge({ direction: 'vertical', position: 455 })
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: {
+        top: '30px',
+        left: null,
+      }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: {
+        top: '60px',
+        left: null,
+      }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: {
+        left: '90px',
+        top: null,
+      }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: {
+        left: '136.5px',
+        top: null,
+      }
+    }
+  ]);
+});
+
+it('adds edges with defaut classes', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const renderer = new Renderer({ document, container: body });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100 }),
+    new Edge({ direction: 'vertical', position: 300 }),
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: { top: '100px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: { left: '300px', top: null, }
+    }
+  ]);
+})
+
+it('adds edge type when supplied by default', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const renderer = new Renderer({ document, container: body });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100, type: 'page' }),
+    new Edge({ direction: 'vertical', position: 300, type: 'normal' }),
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal guide--page',
+      style: { top: '100px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical guide--normal',
+      style: { left: '300px', top: null, }
+    }
+  ]);
+})
+
 test('can remove unused guides', () => {
   const document: DocumentInterface = {
     createElement(tagName: string) {
@@ -90,20 +240,19 @@ test('can remove unused guides', () => {
     }
   };
 
-  const guides = new Renderer({
+  const renderer = new Renderer({
     document,
-    container: body,
-    setup: (element, edge) => element.className = `guide guide--${edge.direction}`
+    container: body
   });
 
-  guides.draw([
+  renderer.draw([
     new Edge({ direction: 'horizontal', position: 100 }),
     new Edge({ direction: 'horizontal', position: 200 }),
     new Edge({ direction: 'vertical', position: 300 }),
     new Edge({ direction: 'vertical', position: 400 })
   ]);
 
-  guides.draw([
+  renderer.draw([
     new Edge({ direction: 'horizontal', position: 100 }),
     new Edge({ direction: 'vertical', position: 300 })
   ]);
@@ -125,5 +274,49 @@ test('can remove unused guides', () => {
         top: null,
       }
     },
+  ]);
+});
+
+it('can take a custom setup', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const renderer = new Renderer({
+    document,
+    container: body,
+    setup: ({ element, edge }) => element.className = `my-${edge.type}-${edge.direction}`
+  });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100, type: 'page' }),
+    new Edge({ direction: 'vertical', position: 300, type: 'normal' }),
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'my-page-horizontal',
+      style: { top: '100px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'my-normal-vertical',
+      style: { left: '300px', top: null, }
+    }
   ]);
 });

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -12,7 +12,7 @@ test('can draw guides', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) {
       this.children.push(child);
@@ -24,7 +24,7 @@ test('can draw guides', () => {
 
   const renderer = new Renderer({
     document,
-    container: body
+    container
   });
 
   renderer.draw([
@@ -77,7 +77,7 @@ test('can have custom positioning guides', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) {
       this.children.push(child);
@@ -89,7 +89,7 @@ test('can have custom positioning guides', () => {
 
   const renderer = new Renderer({
     document,
-    container: body,
+    container,
     positioner: options => {
       const { element, edge } = options;
       const position = edge.position * 0.3;
@@ -148,7 +148,7 @@ it('adds edges with defaut classes', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -160,7 +160,7 @@ it('adds edges with defaut classes', () => {
     }
   };
 
-  const renderer = new Renderer({ document, container: body });
+  const renderer = new Renderer({ document, container });
 
   renderer.draw([
     new Edge({ direction: 'horizontal', position: 100 }),
@@ -188,7 +188,7 @@ it('adds edge type when supplied by default', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -200,7 +200,7 @@ it('adds edge type when supplied by default', () => {
     }
   };
 
-  const renderer = new Renderer({ document, container: body });
+  const renderer = new Renderer({ document, container });
 
   renderer.draw([
     new Edge({ direction: 'horizontal', position: 100, type: 'page' }),
@@ -228,7 +228,7 @@ test('can remove unused guides', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -242,7 +242,7 @@ test('can remove unused guides', () => {
 
   const renderer = new Renderer({
     document,
-    container: body
+    container
   });
 
   renderer.draw([
@@ -284,7 +284,7 @@ it('can take a custom setup', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -298,7 +298,7 @@ it('can take a custom setup', () => {
 
   const renderer = new Renderer({
     document,
-    container: body,
+    container,
     setup: ({ element, edge }) => element.className = `my-${edge.type}-${edge.direction}`
   });
 
@@ -328,7 +328,7 @@ it('can take a custom positioner', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -342,7 +342,7 @@ it('can take a custom positioner', () => {
 
   const renderer = new Renderer({
     document,
-    container: body,
+    container,
     positioner: ({ element, edge }) => {
       element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${edge.position * 2}px`;
     }
@@ -374,7 +374,7 @@ it('can take a custom reset', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -388,7 +388,7 @@ it('can take a custom reset', () => {
 
   const renderer = new Renderer({
     document,
-    container: body,
+    container,
     reset: ({ element }) => {
       element.className += " inactive";
       element.style.top = null;

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -320,3 +320,97 @@ it('can take a custom setup', () => {
     }
   ]);
 });
+
+it('can take a custom positioner', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const renderer = new Renderer({
+    document,
+    container: body,
+    positioner: ({ element, edge }) => {
+      element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${edge.position * 2}px`;
+    }
+  });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100 }),
+    new Edge({ direction: 'vertical', position: 300 }),
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: { top: '200px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: { left: '600px', top: null, }
+    }
+  ]);
+});
+
+it('can take a custom reset', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const renderer = new Renderer({
+    document,
+    container: body,
+    reset: ({ element }) => {
+      element.className += " inactive";
+      element.style.top = null;
+      element.style.left = null;
+    }
+  });
+
+  renderer.draw([
+    new Edge({ direction: 'horizontal', position: 100 }),
+    new Edge({ direction: 'vertical', position: 300 }),
+  ]);
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal inactive',
+      style: { top: '100px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical inactive',
+      style: { left: '300px', top: null, }
+    }
+  ]);
+});

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -34,7 +34,7 @@ test('can draw guides', () => {
     new Edge({ direction: 'vertical', position: 400 })
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -105,7 +105,7 @@ test('can have custom positioning guides', () => {
     new Edge({ direction: 'vertical', position: 455 })
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -167,7 +167,7 @@ it('adds edges with defaut classes', () => {
     new Edge({ direction: 'vertical', position: 300 }),
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -207,7 +207,7 @@ it('adds edge type when supplied by default', () => {
     new Edge({ direction: 'vertical', position: 300, type: 'normal' }),
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal guide--page',
@@ -257,7 +257,7 @@ test('can remove unused guides', () => {
     new Edge({ direction: 'vertical', position: 300 })
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -307,7 +307,7 @@ it('can take a custom setup', () => {
     new Edge({ direction: 'vertical', position: 300, type: 'normal' }),
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'my-page-horizontal',
@@ -353,7 +353,7 @@ it('can take a custom positioner', () => {
     new Edge({ direction: 'vertical', position: 300 }),
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -401,7 +401,7 @@ it('can take a custom reset', () => {
     new Edge({ direction: 'vertical', position: 300 }),
   ]);
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal inactive',

--- a/tests/snapster.test.ts
+++ b/tests/snapster.test.ts
@@ -9,7 +9,7 @@ test('can snap', () => {
     createElement(tagName: string) { return { tagName, className: '', style: {} }; }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) { this.children.push(child); },
     removeChild(child: ElementInterface) {
@@ -17,7 +17,7 @@ test('can snap', () => {
     }
   };
 
-  const snapster = new Snapster({ document: document, container: body });
+  const snapster = new Snapster({ document: document, container });
 
   snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
 
@@ -44,7 +44,7 @@ test('can snap with scale', () => {
     createElement(tagName: string) { return { tagName, className: '', style: {} }; }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) { this.children.push(child); },
     removeChild(child: ElementInterface) {
@@ -54,7 +54,7 @@ test('can snap with scale', () => {
 
   const snapster = new Snapster({
     document: document,
-    container: body,
+    container,
     positioner: ({ element, edge }) => {
       const position = edge.position * 0.3;
 
@@ -89,7 +89,7 @@ test('can clear previous guides', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) { this.children.push(child); },
     removeChild(child: ElementInterface) {
@@ -97,7 +97,7 @@ test('can clear previous guides', () => {
     }
   };
 
-  const snapster = new Snapster({ document: document, container: body });
+  const snapster = new Snapster({ document: document, container });
 
   snapster.populate([{ x: 49, y: 149, width: 300, height: 400 }]);
   snapster.snap({ x: 50, y: 150, width: 500, height: 600 });
@@ -125,7 +125,7 @@ test('can clear snaps', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) { this.children.push(child); },
     removeChild(child: ElementInterface) {
@@ -133,7 +133,7 @@ test('can clear snaps', () => {
     }
   };
 
-  const snapster = new Snapster({ document: document, container: body });
+  const snapster = new Snapster({ document: document, container });
 
   snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
   snapster.snap({ x: 101, y: 201, width: 300, height: 400 });
@@ -149,7 +149,7 @@ it('can take a custom setup', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
     appendChild(child: ElementInterface) { this.children.push(child); },
     removeChild(child: ElementInterface) {
@@ -159,16 +159,16 @@ it('can take a custom setup', () => {
 
   const snapster = new Snapster({
     document,
-    container: body,
+    container,
     setup: ({ element, edge }) => element.className = `my-${edge.type}-${edge.direction}`
   });
-  
+
   snapster.populate([{
     x: 100,
     y: 200,
     width: 500,
     height: 600,
-    type: 'custom'    
+    type: 'custom'
   }]);
   snapster.snap({ x: 101, y: 201, width: 300, height: 400 });
 
@@ -194,7 +194,7 @@ it('can take a custom positioner', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -208,7 +208,7 @@ it('can take a custom positioner', () => {
 
   const snapster = new Snapster({
     document,
-    container: body,
+    container,
     positioner: ({ element, edge }) => {
       element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${edge.position * 2}px`;
     }
@@ -238,7 +238,7 @@ it('can take a custom reset', () => {
     }
   };
 
-  const body: ContainerInterface = {
+  const container: ContainerInterface = {
     children: [],
 
     appendChild(child: ElementInterface) {
@@ -252,7 +252,7 @@ it('can take a custom reset', () => {
 
   const snapster = new Snapster({
     document,
-    container: body,
+    container,
     reset: ({ element }) => {
       element.className += " inactive";
       element.style.top = null;

--- a/tests/snapster.test.ts
+++ b/tests/snapster.test.ts
@@ -39,6 +39,49 @@ test('can snap', () => {
   ]);
 });
 
+test('can snap with scale', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) { return { tagName, className: '', style: {} }; }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+    appendChild(child: ElementInterface) { this.children.push(child); },
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter(existing => existing === child);
+    }
+  };
+
+  const snapster = new Snapster({
+    document: document,
+    container: body,
+    positioner: ({ element, edge }) => {
+      const position = edge.position * 0.3;
+
+      element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${position}px`;
+    }
+  });
+
+  snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
+
+  const position = snapster.snap({ x: 101, y: 201, width: 500, height: 600 });
+
+  expect(position).toEqual({ x: 100, y: 200 });
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: { top: '60px', left: null }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: { left: '30px', top: null }
+    }
+  ]);
+});
+
 test('can clear previous guides', () => {
   const document: DocumentInterface = {
     createElement(tagName: string) {
@@ -97,4 +140,4 @@ test('can clear snaps', () => {
   snapster.clear();
 
   expect(body.children).toEqual([]);
- })
+});

--- a/tests/snapster.test.ts
+++ b/tests/snapster.test.ts
@@ -141,3 +141,138 @@ test('can clear snaps', () => {
 
   expect(body.children).toEqual([]);
 });
+
+it('can take a custom setup', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+    appendChild(child: ElementInterface) { this.children.push(child); },
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter(existing => existing === child);
+    }
+  };
+
+  const snapster = new Snapster({
+    document,
+    container: body,
+    setup: ({ element, edge }) => element.className = `my-${edge.type}-${edge.direction}`
+  });
+  
+  snapster.populate([{
+    x: 100,
+    y: 200,
+    width: 500,
+    height: 600,
+    type: 'custom'    
+  }]);
+  snapster.snap({ x: 101, y: 201, width: 300, height: 400 });
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'my-custom-horizontal',
+      style: { top: '200px', left: null }
+    },
+    {
+      tagName: 'div',
+      className: 'my-custom-vertical',
+      style: { left: '100px', top: null }
+    }
+  ]);
+
+});
+
+it('can take a custom positioner', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const snapster = new Snapster({
+    document,
+    container: body,
+    positioner: ({ element, edge }) => {
+      element.style[edge.direction === 'horizontal' ? 'top' : 'left'] = `${edge.position * 2}px`;
+    }
+  });
+
+  snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
+  snapster.snap({ x: 101, y: 201, width: 500, height: 600 });
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal',
+      style: { top: '400px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical',
+      style: { left: '200px', top: null, }
+    }
+  ]);
+});
+
+it('can take a custom reset', () => {
+  const document: DocumentInterface = {
+    createElement(tagName: string) {
+      return { tagName, className: '', style: {} };
+    }
+  };
+
+  const body: ContainerInterface = {
+    children: [],
+
+    appendChild(child: ElementInterface) {
+      this.children.push(child);
+    },
+
+    removeChild(child: ElementInterface) {
+      this.children = this.children.filter((existing: ElementInterface) => existing !== child);
+    }
+  };
+
+  const snapster = new Snapster({
+    document,
+    container: body,
+    reset: ({ element }) => {
+      element.className += " inactive";
+      element.style.top = null;
+      element.style.left = null;
+    }
+  });
+
+  snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
+  snapster.snap({ x: 101, y: 201, width: 500, height: 600 });
+
+  expect(body.children).toEqual([
+    {
+      tagName: 'div',
+      className: 'guide guide--horizontal inactive',
+      style: { top: '200px', left: null, }
+    },
+    {
+      tagName: 'div',
+      className: 'guide guide--vertical inactive',
+      style: { left: '100px', top: null, }
+    }
+  ]);
+});

--- a/tests/snapster.test.ts
+++ b/tests/snapster.test.ts
@@ -25,7 +25,7 @@ test('can snap', () => {
 
   expect(position).toEqual({ x: 100, y: 200 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -68,7 +68,7 @@ test('can snap with scale', () => {
 
   expect(position).toEqual({ x: 100, y: 200 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -104,7 +104,7 @@ test('can clear previous guides', () => {
   snapster.populate([{ x: 51, y: 151, width: 300, height: 400 }]);
   snapster.snap({ x: 50, y: 150, width: 500, height: 600 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       className: 'guide guide--horizontal',
       style: { left: null, top: '151px' },
@@ -139,7 +139,7 @@ test('can clear snaps', () => {
   snapster.snap({ x: 101, y: 201, width: 300, height: 400 });
   snapster.clear();
 
-  expect(body.children).toEqual([]);
+  expect(container.children).toEqual([]);
 });
 
 it('can take a custom setup', () => {
@@ -172,7 +172,7 @@ it('can take a custom setup', () => {
   }]);
   snapster.snap({ x: 101, y: 201, width: 300, height: 400 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'my-custom-horizontal',
@@ -217,7 +217,7 @@ it('can take a custom positioner', () => {
   snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
   snapster.snap({ x: 101, y: 201, width: 500, height: 600 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal',
@@ -263,7 +263,7 @@ it('can take a custom reset', () => {
   snapster.populate([{ x: 100, y: 200, width: 300, height: 400 }]);
   snapster.snap({ x: 101, y: 201, width: 500, height: 600 });
 
-  expect(body.children).toEqual([
+  expect(container.children).toEqual([
     {
       tagName: 'div',
       className: 'guide guide--horizontal inactive',


### PR DESCRIPTION
- Write test to validate that scaling happens correctly via a custom positioner method.
- Write test to validate that a custom reset passed into the renderer is called.
- Write test to validate that a setup method passed into the renderer setups guides using the new setup method.
- Add the ability to pass a positioner, reset and setup method to Snapster.
- Write tests for the custom callbacks when they are passed into Snapster.